### PR TITLE
Always On Lateral

### DIFF
--- a/common/params.cc
+++ b/common/params.cc
@@ -207,6 +207,19 @@ std::unordered_map<std::string, uint32_t> keys = {
     {"Version", PERSISTENT},
     {"VisionRadarToggle", PERSISTENT},
     {"WheeledBody", PERSISTENT},
+
+    // PFEIFER - AOL {{
+    {"AlwaysOnLateralEnabled", PERSISTENT},
+    {"AlwaysOnLateralEnabledLock", PERSISTENT | CLEAR_ON_OFFROAD_TRANSITION},
+    {"AlwaysOnLateralEnabledConfirmed", PERSISTENT},
+    {"AlwaysOnLateralMainEnablesConfirmed", PERSISTENT},
+    {"AlwaysOnLateralMainEnables", PERSISTENT},
+    {"AlwaysOnLateralType", PERSISTENT},
+    {"LateralAllowed", PERSISTENT},
+    {"LateralActive", CLEAR_ON_MANAGER_START | CLEAR_ON_ONROAD_TRANSITION},
+    {"DisengageLatOnBrake", PERSISTENT},
+    {"DisengageLatOnBlinker", PERSISTENT},
+    // }} PFEIFER - AOL
 };
 
 } // namespace

--- a/release/files_common
+++ b/release/files_common
@@ -605,3 +605,5 @@ tinygrad_repo/tinygrad/nn/*
 tinygrad_repo/tinygrad/runtime/ops_gpu.py
 tinygrad_repo/tinygrad/shape/*
 tinygrad_repo/tinygrad/*.py
+
+selfdrive/controls/always_on_lateral.py

--- a/selfdrive/car/chrysler/carstate.py
+++ b/selfdrive/car/chrysler/carstate.py
@@ -5,6 +5,10 @@ from opendbc.can.can_define import CANDefine
 from openpilot.selfdrive.car.interfaces import CarStateBase
 from openpilot.selfdrive.car.chrysler.values import DBC, STEER_THRESHOLD, RAM_CARS
 
+# PFEIFER - AOL {{
+from openpilot.selfdrive.controls.always_on_lateral import AlwaysOnLateral, AlwaysOnLateralType
+# }} PFEIFER - AOL
+
 
 class CarState(CarStateBase):
   def __init__(self, CP):
@@ -20,6 +24,10 @@ class CarState(CarStateBase):
       self.shifter_values = can_define.dv["Transmission_Status"]["Gear_State"]
     else:
       self.shifter_values = can_define.dv["GEAR"]["PRNDL"]
+
+    # PFEIFER - AOL {{
+    AlwaysOnLateral.set_always_on_lateral_type(AlwaysOnLateralType.CRUISE_STATE)
+    # }} PFEIFER - AOL
 
   def update(self, cp, cp_cam):
 

--- a/selfdrive/car/ford/carstate.py
+++ b/selfdrive/car/ford/carstate.py
@@ -6,6 +6,10 @@ from openpilot.selfdrive.car.interfaces import CarStateBase
 from openpilot.selfdrive.car.ford.fordcan import CanBus
 from openpilot.selfdrive.car.ford.values import CANFD_CAR, CarControllerParams, DBC
 
+# PFEIFER - AOL {{
+from openpilot.selfdrive.controls.always_on_lateral import AlwaysOnLateral, AlwaysOnLateralType
+# }} PFEIFER - AOL
+
 GearShifter = car.CarState.GearShifter
 TransmissionType = car.CarParams.TransmissionType
 
@@ -19,6 +23,10 @@ class CarState(CarStateBase):
 
     self.vehicle_sensors_valid = False
     self.hybrid_platform = False
+
+    # PFEIFER - AOL {{
+    AlwaysOnLateral.set_always_on_lateral_type(AlwaysOnLateralType.CRUISE_STATE)
+    # }} PFEIFER - AOL
 
   def update(self, cp, cp_cam):
     ret = car.CarState.new_message()

--- a/selfdrive/car/gm/carstate.py
+++ b/selfdrive/car/gm/carstate.py
@@ -7,6 +7,10 @@ from opendbc.can.parser import CANParser
 from openpilot.selfdrive.car.interfaces import CarStateBase
 from openpilot.selfdrive.car.gm.values import DBC, AccState, CanBus, STEER_THRESHOLD
 
+# PFEIFER - AOL {{
+from openpilot.selfdrive.controls.always_on_lateral import AlwaysOnLateral, AlwaysOnLateralType
+# }} PFEIFER - AOL
+
 TransmissionType = car.CarParams.TransmissionType
 NetworkLocation = car.CarParams.NetworkLocation
 STANDSTILL_THRESHOLD = 10 * 0.0311 * CV.KPH_TO_MS
@@ -25,6 +29,10 @@ class CarState(CarStateBase):
     self.pt_lka_steering_cmd_counter = 0
     self.cam_lka_steering_cmd_counter = 0
     self.buttons_counter = 0
+
+    # PFEIFER - AOL {{
+    AlwaysOnLateral.set_always_on_lateral_type(AlwaysOnLateralType.CRUISE_STATE)
+    # }} PFEIFER - AOL
 
   def update(self, pt_cp, cam_cp, loopback_cp):
     ret = car.CarState.new_message()

--- a/selfdrive/car/honda/carstate.py
+++ b/selfdrive/car/honda/carstate.py
@@ -11,6 +11,10 @@ from openpilot.selfdrive.car.honda.values import CAR, DBC, STEER_THRESHOLD, HOND
                                                  HONDA_BOSCH_RADARLESS
 from openpilot.selfdrive.car.interfaces import CarStateBase
 
+# PFEIFER - AOL {{
+from openpilot.selfdrive.controls.always_on_lateral import AlwaysOnLateral, AlwaysOnLateralType
+# }} PFEIFER - AOL
+
 TransmissionType = car.CarParams.TransmissionType
 
 
@@ -107,6 +111,10 @@ class CarState(CarStateBase):
     # When available we use cp.vl["CAR_SPEED"]["ROUGH_CAR_SPEED_2"] to populate vEgoCluster
     # However, on cars without a digital speedometer this is not always present (HRV, FIT, CRV 2016, ILX and RDX)
     self.dash_speed_seen = False
+
+    # PFEIFER - AOL {{
+    AlwaysOnLateral.set_always_on_lateral_type(AlwaysOnLateralType.CRUISE_STATE)
+    # }} PFEIFER - AOL
 
   def update(self, cp, cp_cam, cp_body):
     ret = car.CarState.new_message()

--- a/selfdrive/car/hyundai/carstate.py
+++ b/selfdrive/car/hyundai/carstate.py
@@ -11,6 +11,10 @@ from openpilot.selfdrive.car.hyundai.values import HyundaiFlags, CAR, DBC, CAN_G
                                                    CANFD_CAR, EV_CAR, HYBRID_CAR, Buttons, CarControllerParams
 from openpilot.selfdrive.car.interfaces import CarStateBase
 
+# PFEIFER - AOL {{
+from openpilot.selfdrive.controls.always_on_lateral import AlwaysOnLateral, AlwaysOnLateralType
+# }} PFEIFER - AOL
+
 PREV_BUTTON_SAMPLES = 8
 CLUSTER_SAMPLE_RATE = 20  # frames
 STANDSTILL_THRESHOLD = 12 * 0.03125 * CV.KPH_TO_MS
@@ -105,11 +109,17 @@ class CarState(CarStateBase):
       ret.cruiseState.available = cp.vl["TCS13"]["ACCEnable"] == 0
       ret.cruiseState.enabled = cp.vl["TCS13"]["ACC_REQ"] == 1
       ret.cruiseState.standstill = False
+      # PFEIFER - AOL {{
+      AlwaysOnLateral.set_always_on_lateral_type(AlwaysOnLateralType.BUTTON)
+      # }} PFEIFER - AOL
     else:
       ret.cruiseState.available = cp_cruise.vl["SCC11"]["MainMode_ACC"] == 1
       ret.cruiseState.enabled = cp_cruise.vl["SCC12"]["ACCMode"] != 0
       ret.cruiseState.standstill = cp_cruise.vl["SCC11"]["SCCInfoDisplay"] == 4.
       ret.cruiseState.speed = cp_cruise.vl["SCC11"]["VSetDis"] * speed_conv
+      # PFEIFER - AOL {{
+      AlwaysOnLateral.set_always_on_lateral_type(AlwaysOnLateralType.CRUISE_STATE)
+      # }} PFEIFER - AOL
 
     # TODO: Find brake pressure
     ret.brake = 0
@@ -159,11 +169,22 @@ class CarState(CarStateBase):
     self.steer_state = cp.vl["MDPS12"]["CF_Mdps_ToiActive"]  # 0 NOT ACTIVE, 1 ACTIVE
     self.prev_cruise_buttons = self.cruise_buttons[-1]
     self.cruise_buttons.extend(cp.vl_all["CLU11"]["CF_Clu_CruiseSwState"])
+    # PFEIFER - AOL {{
+    self.prev_main_buttons = self.main_buttons[-1]
+    # }} PFEIFER - AOL
     self.main_buttons.extend(cp.vl_all["CLU11"]["CF_Clu_CruiseSwMain"])
+    # PFEIFER - AOL {{
+    if self.prev_main_buttons == 0 and self.main_buttons[-1] != 0:
+      AlwaysOnLateral.toggle_lateral_allowed()
+    # }} PFEIFER - AOL
 
     return ret
 
   def update_canfd(self, cp, cp_cam):
+    # PFEIFER - AOL {{
+    AlwaysOnLateral.set_always_on_lateral_type(AlwaysOnLateralType.BUTTON)
+    # }} PFEIFER - AOL
+
     ret = car.CarState.new_message()
 
     self.is_metric = cp.vl["CRUISE_BUTTONS_ALT"]["DISTANCE_UNIT"] != 1
@@ -228,7 +249,14 @@ class CarState(CarStateBase):
 
     self.prev_cruise_buttons = self.cruise_buttons[-1]
     self.cruise_buttons.extend(cp.vl_all[self.cruise_btns_msg_canfd]["CRUISE_BUTTONS"])
+    # PFEIFER - AOL {{
+    self.prev_main_buttons = self.main_buttons[-1]
+    # }} PFEIFER - AOL
     self.main_buttons.extend(cp.vl_all[self.cruise_btns_msg_canfd]["ADAPTIVE_CRUISE_MAIN_BTN"])
+    # PFEIFER - AOL {{
+    if self.main_buttons[-1] != self.prev_main_buttons:
+        AlwaysOnLateral.toggle_lateral_allowed()
+    # }} PFEIFER - AOL
     self.buttons_counter = cp.vl[self.cruise_btns_msg_canfd]["COUNTER"]
     ret.accFaulted = cp.vl["TCS"]["ACCEnable"] != 0  # 0 ACC CONTROL ENABLED, 1-3 ACC CONTROL DISABLED
 

--- a/selfdrive/car/interfaces.py
+++ b/selfdrive/car/interfaces.py
@@ -327,6 +327,10 @@ class CarStateBase(ABC):
     self.car_fingerprint = CP.carFingerprint
     self.out = car.CarState.new_message()
 
+    # PFEIFER - AOL {{
+    self.lateral_allowed = False
+    # }} PFEIFER - AOL
+
     self.cruise_buttons = 0
     self.left_blinker_cnt = 0
     self.right_blinker_cnt = 0

--- a/selfdrive/car/mazda/carstate.py
+++ b/selfdrive/car/mazda/carstate.py
@@ -5,6 +5,10 @@ from opendbc.can.parser import CANParser
 from openpilot.selfdrive.car.interfaces import CarStateBase
 from openpilot.selfdrive.car.mazda.values import DBC, LKAS_LIMITS, GEN1
 
+# PFEIFER - AOL {{
+from openpilot.selfdrive.controls.always_on_lateral import AlwaysOnLateral, AlwaysOnLateralType
+# }} PFEIFER - AOL
+
 class CarState(CarStateBase):
   def __init__(self, CP):
     super().__init__(CP)
@@ -17,6 +21,10 @@ class CarState(CarStateBase):
     self.low_speed_alert = False
     self.lkas_allowed_speed = False
     self.lkas_disabled = False
+
+    # PFEIFER - AOL {{
+    AlwaysOnLateral.set_always_on_lateral_type(AlwaysOnLateralType.CRUISE_STATE)
+    # }} PFEIFER - AOL
 
   def update(self, cp, cp_cam):
 

--- a/selfdrive/car/subaru/carstate.py
+++ b/selfdrive/car/subaru/carstate.py
@@ -7,6 +7,10 @@ from opendbc.can.parser import CANParser
 from openpilot.selfdrive.car.subaru.values import DBC, GLOBAL_GEN2, PREGLOBAL_CARS, HYBRID_CARS, CanBus, SubaruFlags
 from openpilot.selfdrive.car import CanSignalRateCalculator
 
+# PFEIFER - AOL {{
+from openpilot.selfdrive.controls.always_on_lateral import AlwaysOnLateral, AlwaysOnLateralType
+# }} PFEIFER - AOL
+
 
 class CarState(CarStateBase):
   def __init__(self, CP):
@@ -15,6 +19,10 @@ class CarState(CarStateBase):
     self.shifter_values = can_define.dv["Transmission"]["Gear"]
 
     self.angle_rate_calulator = CanSignalRateCalculator(50)
+
+    # PFEIFER - AOL {{
+    AlwaysOnLateral.set_always_on_lateral_type(AlwaysOnLateralType.CRUISE_STATE)
+    # }} PFEIFER - AOL
 
   def update(self, cp, cp_cam, cp_body):
     ret = car.CarState.new_message()

--- a/selfdrive/car/tesla/carstate.py
+++ b/selfdrive/car/tesla/carstate.py
@@ -7,6 +7,10 @@ from openpilot.selfdrive.car.interfaces import CarStateBase
 from opendbc.can.parser import CANParser
 from opendbc.can.can_define import CANDefine
 
+# PFEIFER - AOL {{
+from openpilot.selfdrive.controls.always_on_lateral import AlwaysOnLateral, AlwaysOnLateralType
+# }} PFEIFER - AOL
+
 class CarState(CarStateBase):
   def __init__(self, CP):
     super().__init__(CP)
@@ -19,6 +23,10 @@ class CarState(CarStateBase):
     self.steer_warning = None
     self.acc_state = 0
     self.das_control_counters = deque(maxlen=32)
+
+    # PFEIFER - AOL {{
+    AlwaysOnLateral.set_always_on_lateral_type(AlwaysOnLateralType.CRUISE_STATE)
+    # }} PFEIFER - AOL
 
   def update(self, cp, cp_cam):
     ret = car.CarState.new_message()

--- a/selfdrive/car/toyota/carstate.py
+++ b/selfdrive/car/toyota/carstate.py
@@ -24,6 +24,10 @@ TEMP_STEER_FAULTS = (0, 9, 11, 21, 25)
 # - prolonged high driver torque: 17 (permanent)
 PERM_STEER_FAULTS = (3, 17)
 
+# PFEIFER - AOL {{
+from openpilot.selfdrive.controls.always_on_lateral import AlwaysOnLateral, AlwaysOnLateralType
+# }} PFEIFER - AOL
+
 
 class CarState(CarStateBase):
   def __init__(self, CP):
@@ -43,6 +47,10 @@ class CarState(CarStateBase):
     self.low_speed_lockout = False
     self.acc_type = 1
     self.lkas_hud = {}
+
+    # PFEIFER - AOL {{
+    AlwaysOnLateral.set_always_on_lateral_type(AlwaysOnLateralType.CRUISE_STATE)
+    # }} PFEIFER - AOL
 
   def update(self, cp, cp_cam):
     ret = car.CarState.new_message()

--- a/selfdrive/car/volkswagen/carstate.py
+++ b/selfdrive/car/volkswagen/carstate.py
@@ -6,6 +6,10 @@ from opendbc.can.parser import CANParser
 from openpilot.selfdrive.car.volkswagen.values import DBC, CANBUS, PQ_CARS, NetworkLocation, TransmissionType, GearShifter, \
                                             CarControllerParams
 
+# PFEIFER - AOL {{
+from openpilot.selfdrive.controls.always_on_lateral import AlwaysOnLateral, AlwaysOnLateralType
+# }} PFEIFER - AOL
+
 
 class CarState(CarStateBase):
   def __init__(self, CP):
@@ -14,6 +18,10 @@ class CarState(CarStateBase):
     self.button_states = {button.event_type: False for button in self.CCP.BUTTONS}
     self.esp_hold_confirmation = False
     self.upscale_lead_car_signal = False
+
+    # PFEIFER - AOL {{
+    AlwaysOnLateral.set_always_on_lateral_type(AlwaysOnLateralType.CRUISE_STATE)
+    # }} PFEIFER - AOL
 
   def create_button_events(self, pt_cp, buttons):
     button_events = []

--- a/selfdrive/controls/always_on_lateral.py
+++ b/selfdrive/controls/always_on_lateral.py
@@ -1,0 +1,295 @@
+# PFEIFER - AOL
+
+# Acknowledgements:
+# Huge thanks to the following forks, much of my initial implementation used these as a reference:
+#   * Sunnypilot - https://github.com/sunnyhaibin/sunnypilot
+#   * Ghostpilot - https://github.com/spektor56/ghostpilot
+#   * Alexander Sato's fork - https://github.com/AlexandreSato/openpilot/tree/personal3
+#
+# Another huge thanks goes out to Frogai. Working with him on Toyota support lead to a pretty generic method to support
+# nearly every brand. https://github.com/frogAi/FrogPilot
+#
+# A huge thanks also goes out to nworby for his continued attention to detail and diligence that has lead to many
+# improvements to the safety of this implementation
+
+from cereal import log, car
+from openpilot.common.params import Params, put_bool_nonblocking
+from openpilot.selfdrive.controls.lib.latcontrol import MIN_LATERAL_CONTROL_SPEED
+from panda import ALTERNATIVE_EXPERIENCE
+from openpilot.selfdrive.controls.lib.events import EngagementAlert, AudibleAlert
+from openpilot.selfdrive.controls.lib.events import ET
+from enum import IntEnum
+from openpilot.common.realtime import DT_CTRL
+
+State = log.ControlsState.OpenpilotState
+ACTIVE_STATES = (State.enabled, State.softDisabling, State.overriding)
+
+params = Params()
+mem_params = Params("/dev/shm/params")
+"""
+A speed optimization, Params with a base path in /dev/shm/params.
+
+/dev/shm is a memory mapped folder and does not persistently store across
+reboots. The advantage to using a memory mapped folder is that it should be
+very fast and consistent for both writes and reads.
+
+If using the real filesystem placing data can, in extreme circumstances,
+take over 1 second. put_bool_nonblocking helps with this by creating a
+thread but this can create race conditions. If we need to block but don't
+care about persistence across reboots the memory mapped location should
+avoid random lag.
+"""
+
+SOFT_DISABLE_TIME = 3  # seconds
+
+class AlwaysOnLateralType(IntEnum):
+  STOCK_OP = 0
+  CRUISE_STATE = 1
+  BUTTON = 2
+
+class AlwaysOnLateral:
+  def __init__(self, CI, controls):
+    self.CI = CI
+    self.controls = controls
+
+    # UI Toggles
+    self.enabled: bool = False
+    self.main_enables: bool = False
+    self.disengage_lat_on_brake: bool = False
+    self.disengage_lat_on_blinker: bool = False
+
+    # Car State
+    self.braking: bool = False
+    self.blinkers_active: bool = False
+    self.standstill: bool = False
+    self.steer_fault: bool = False
+    self.invalid_gear: bool = False
+    self.cruise_available: bool = False
+    self.cruise_enabled: bool = False
+
+    # OP/AOL states
+    self.cruise_previously_engaged: bool = False
+    self.last_lat_allowed: bool = False
+    self.op_active: bool = False
+    self.aol_type: AlwaysOnLateralType = AlwaysOnLateralType.STOCK_OP
+    self.prev_lat_active: bool = False
+    self.calibrated: bool = False
+
+    # This is used to disable aol in the event that openpilot has received a
+    # disable event. aol will only be re-enabled once openpilot has been
+    # re-engaged.
+    self.disabled: bool = False
+    self.soft_disabling: bool = False
+    self.soft_disable_timer: float = 0.0
+
+    params.put_bool("AlwaysOnLateralEnabledLock", True) # locks toggle when onroad
+
+
+
+  @staticmethod
+  def set_always_on_lateral_type(typ: AlwaysOnLateralType):
+    mem_params.put("AlwaysOnLateralType", str(int(typ)))
+
+  @staticmethod
+  def get_always_on_lateral_type() -> AlwaysOnLateralType:
+    try:
+      return AlwaysOnLateralType(int(mem_params.get("AlwaysOnLateralType")))
+    except:
+      return AlwaysOnLateralType.STOCK_OP
+
+  @staticmethod
+  def get_lateral_allowed() -> bool:
+    return mem_params.get_bool("LateralAllowed")
+
+  @staticmethod
+  def set_lateral_allowed(lateral_allowed: bool) -> None:
+    mem_params.put_bool("LateralAllowed", lateral_allowed)
+
+  @staticmethod
+  def toggle_lateral_allowed() -> None:
+    lateral_allowed = AlwaysOnLateral.get_lateral_allowed()
+    AlwaysOnLateral.set_lateral_allowed(not lateral_allowed)
+
+  def handle_audible_alert(self, alert_manager, sm, lateral_allowed: bool):
+    if self.last_lat_allowed != lateral_allowed:
+      alert = None
+      if lateral_allowed:
+        alert = EngagementAlert(AudibleAlert.engage)
+      else:
+        alert = EngagementAlert(AudibleAlert.disengage)
+      alert_manager.add_many(sm.frame, [alert])
+
+  def update_cruise_previously_engaged(self):
+    if not self.cruise_available:
+      self.cruise_previously_engaged = False
+    self.cruise_previously_engaged |= self.op_active
+
+  def check_aol_state(self) -> bool:
+    if not self.enabled:
+      return False
+
+    if self.disabled:
+      return False
+
+    if self.aol_type == AlwaysOnLateralType.STOCK_OP:
+      return self.op_active
+    elif self.aol_type == AlwaysOnLateralType.CRUISE_STATE:
+      if self.main_enables:
+        return self.cruise_available
+      return self.cruise_previously_engaged and self.cruise_available
+    elif self.aol_type == AlwaysOnLateralType.BUTTON:
+      if self.main_enables:
+        return self.cruise_available and AlwaysOnLateral.get_lateral_allowed()
+      return self.cruise_previously_engaged and self.cruise_available and AlwaysOnLateral.get_lateral_allowed()
+
+    # Should be unreachable
+    return False
+
+  def update(self, car_state, op_state, car_params, sm, alert_manager):
+    panda_states = sm['pandaStates']
+    self.op_active = op_state in ACTIVE_STATES
+
+    # Clear disabled state if OP is enabled
+    if op_state == State.enabled:
+      self.disabled = False
+
+    self.aol_type = AlwaysOnLateral.get_always_on_lateral_type()
+    lateral_allowed = self.check_aol_state()
+    self.handle_audible_alert(alert_manager, sm, lateral_allowed)
+
+    self.enabled = params.get_bool('AlwaysOnLateralEnabled')
+    self.main_enables = params.get_bool('AlwaysOnLateralMainEnables')
+    self.disengage_lat_on_brake = params.get_bool('DisengageLatOnBrake')
+    self.disengage_lat_on_blinker = params.get_bool('DisengageLatOnBlinker')
+
+    self.cruise_available = car_state.cruiseState.available
+    self.cruise_enabled = car_state.cruiseState.enabled
+
+    self.update_cruise_previously_engaged()
+
+
+    self.braking = car_state.brakePressed or car_state.regenBraking
+    self.blinkers_active = car_state.leftBlinker or car_state.rightBlinker
+    self.standstill = car_state.vEgo <= max(car_params.minSteerSpeed, MIN_LATERAL_CONTROL_SPEED) or car_state.standstill
+    self.steer_fault = car_state.steerFaultTemporary or car_state.steerFaultPermanent
+    self.invalid_gear = car_state.gearShifter not in [car.CarState.GearShifter.drive, car.CarState.GearShifter.sport, car.CarState.GearShifter.low, car.CarState.GearShifter.eco]
+    self.calibrated = sm['liveCalibration'].calStatus == log.LiveCalibrationData.Status.calibrated
+
+    # Check events to see if we should disable or soft disable
+    self.check_event_state()
+
+    # Always allow lateral when controls are allowed
+    if any(ps.controlsAllowed for ps in panda_states) and not lateral_allowed and not self.disabled:
+      AlwaysOnLateral.set_lateral_allowed(True)
+
+    self.last_lat_allowed = lateral_allowed
+
+  @property
+  def _lat_active(self):
+
+    # If we're in a disabled state due to events, don't allow lateral
+    if self.disabled:
+      return False
+
+    # cruise state must be reporting available to send lateral controls
+    if not self.cruise_available:
+      return False
+
+    # Require engaging cruise control at least once before keeping lateral on
+    # This helps to prevent cruise faults in some cars
+    if not self.cruise_previously_engaged and not self.main_enables:
+      return False
+
+    # If car is in a gear that does not move forward do not engage lateral
+    if self.invalid_gear:
+      return False
+
+    # If there is a steer fault lat is not available
+    if self.steer_fault:
+      return False
+
+    # If OP is not calibrated lat is not available
+    if not self.calibrated:
+      return False
+
+    # Disable lateral when vehicle is stopped to prevent "twitching" steering wheel
+    if self.standstill:
+      return False
+
+    # Track the main button for BUTTON type aol
+    if self.enabled and self.aol_type == AlwaysOnLateralType.BUTTON and not self.get_lateral_allowed():
+      return False
+
+    # lat is only active when openpilot is active if aol is disabled or we do not support AOL for the car
+    if (not self.enabled or self.aol_type == AlwaysOnLateralType.STOCK_OP) and not self.op_active:
+      return False
+
+    # If DisengageLatOnBrake is enabled we disable lat when braking
+    if self.disengage_lat_on_brake and self.braking:
+      return False
+
+    # If DisengageLatOnBlinker is enabled we disable lat when blinkers are on
+    if self.disengage_lat_on_blinker and self.blinkers_active and not self.op_active:
+      return False
+
+    # Lat is active if we pass all previous tests for disengagement
+    return True
+
+  def check_event_state(self):
+    self.soft_disable_timer = max(0, self.soft_disable_timer - 1)
+    if not self.lat_active:
+      return
+
+    if self.disabled:
+      return
+
+    if self.controls.events.contains(ET.IMMEDIATE_DISABLE):
+      self.disabled = True
+      self.soft_disabling = False
+      self.controls.state = State.disabled
+      # only alert if OP is not active as it will alert itself
+      if not self.op_active:
+        self.controls.current_alert_types.append(ET.IMMEDIATE_DISABLE)
+    elif self.soft_disabling:
+      if not self.controls.events.contains(ET.SOFT_DISABLE):
+        # no more soft disabling condition, so go back to ENABLED
+        self.soft_disabling = False
+
+      elif self.soft_disable_timer > 0:
+        self.controls.current_alert_types.append(ET.SOFT_DISABLE)
+        # only alert if OP is not active as it will alert itself
+        if not self.op_active:
+          self.controls.current_alert_types.append(ET.SOFT_DISABLE)
+
+      elif self.soft_disable_timer <= 0:
+        self.disabled = True
+        self.soft_disabling = False
+        self.controls.state = State.disabled
+    elif self.controls.events.contains(ET.SOFT_DISABLE):
+      self.soft_disabling = True
+      self.soft_disable_timer = int(SOFT_DISABLE_TIME / DT_CTRL)
+      # only alert if OP is not active as it will alert itself
+      if not self.op_active:
+        self.controls.current_alert_types.append(ET.SOFT_DISABLE)
+
+  @property
+  def lat_active(self):
+    lat_active = self._lat_active
+
+    # push lat active to the ui
+    if self.prev_lat_active != lat_active:
+      put_bool_nonblocking("LateralActive", lat_active)
+
+    self.prev_lat_active = lat_active
+    return lat_active
+
+  @property
+  def alternative_experience(self):
+    always_on_lateral_enabled = params.get_bool('AlwaysOnLateralEnabled')
+    always_on_lateral_main_enables = params.get_bool('AlwaysOnLateralMainEnables')
+    experience = 0
+    if always_on_lateral_enabled:
+      experience |= ALTERNATIVE_EXPERIENCE.ENABLE_ALWAYS_ON_LATERAL
+    if always_on_lateral_main_enables:
+      experience |= ALTERNATIVE_EXPERIENCE.AOL_ENABLE_ON_MAIN
+    return experience

--- a/selfdrive/ui/qt/offroad/settings.cc
+++ b/selfdrive/ui/qt/offroad/settings.cc
@@ -72,6 +72,36 @@ TogglesPanel::TogglesPanel(SettingsWindow *parent) : ListWidget(parent) {
       tr("Display speed in km/h instead of mph."),
       "../assets/offroad/icon_metric.png",
     },
+    // PFEIFER - AOL {{
+    {
+      "AlwaysOnLateralEnabled",
+      tr("Always on Lateral"),
+      QString("<b>%1</b><br><br>%2")
+      .arg(tr("WARNING: Always on lateral has not been tested on all cars. You may receive cruise faults when disabling longitudinal control if this is not compatible with your car. Please test in a safe environment before using on road."))
+      .arg(tr("When enabled lateral control will remain engaged after longitudinal is disengaged. Main cruise button toggles lateral control off.")),
+      "../assets/img_experimental_white.svg",
+    },
+    {
+      "AlwaysOnLateralMainEnables",
+      tr("Main cruise engages AOL"),
+      QString("<b>%1</b><br><br>%2")
+      .arg(tr("WARNING: Engaging lateral upon toggling main cruise likely has issues with many cars. You may receive cruise faults upon pressing the main cruise button. Please test in a safe environment before using on road."))
+      .arg(tr("Engages Always on Lateral whenever main is pressed.")),
+      "../assets/img_experimental_white.svg",
+    },
+    {
+      "DisengageLatOnBrake",
+      tr("Disengage Lateral on Brake Pedal"),
+      tr("Disables lateral while the brake is being applied. Only changes behavior of Always on Lateral."),
+      "../assets/img_experimental_white.svg",
+    },
+    {
+      "DisengageLatOnBlinker",
+      tr("Disengage Lateral on Blinker"),
+      tr("Disables lateral while a blinker is being activated. Only changes behavior of Always on Lateral."),
+      "../assets/img_experimental_white.svg",
+    },
+    // }} PFEIFER - AOL
 #ifdef ENABLE_MAPS
     {
       "NavSettingTime24h",
@@ -114,6 +144,10 @@ TogglesPanel::TogglesPanel(SettingsWindow *parent) : ListWidget(parent) {
   toggles["ExperimentalMode"]->setActiveIcon("../assets/img_experimental.svg");
   toggles["ExperimentalMode"]->setConfirmation(true, true);
   toggles["ExperimentalLongitudinalEnabled"]->setConfirmation(true, false);
+  // PFEIFER - AOL {{
+  toggles["AlwaysOnLateralEnabled"]->setConfirmation(true, true);
+  toggles["AlwaysOnLateralMainEnables"]->setConfirmation(true, true);
+  // }} PFEIFER - AOL
 
   connect(toggles["ExperimentalLongitudinalEnabled"], &ToggleControl::toggleFlipped, [=]() {
     updateToggles();
@@ -150,6 +184,14 @@ void TogglesPanel::updateToggles() {
                                   .arg(tr("New Driving Visualization"))
                                   .arg(tr("The driving visualization will transition to the road-facing wide-angle camera at low speeds to better show some turns. The Experimental mode logo will also be shown in the top right corner. "
                                           "When a navigation destination is set and the driving model is using it as input, the driving path on the map will turn green."));
+
+  // PFEIFER - AOL {{
+  auto aol_toggle = toggles["AlwaysOnLateralEnabled"];
+  auto aol_main_toggle = toggles["AlwaysOnLateralMainEnables"];
+  bool aol_locked = params.getBool("AlwaysOnLateralEnabledLock");
+  aol_toggle->setEnabled(!aol_locked);
+  aol_main_toggle->setEnabled(!aol_locked);
+  // }} PFEIFER - AOL
 
   const bool is_release = params.getBool("IsReleaseBranch");
   auto cp_bytes = params.get("CarParamsPersistent");

--- a/selfdrive/ui/qt/onroad.cc
+++ b/selfdrive/ui/qt/onroad.cc
@@ -72,6 +72,13 @@ void OnroadWindow::updateState(const UIState &s) {
   }
 
   QColor bgColor = bg_colors[s.status];
+  // PFEIFER - AOL {{
+  params = Params();
+  if(s.status == STATUS_DISENGAGED && params.getBool("LateralActive")){
+      bgColor = bg_colors[STATUS_LAT_ACTIVE];
+  }
+  // }} PFEIFER - AOL
+
   Alert alert = Alert::get(*(s.sm), s.scene.started_frame);
   alerts->updateAlert(alert);
 

--- a/selfdrive/ui/qt/onroad.h
+++ b/selfdrive/ui/qt/onroad.h
@@ -134,6 +134,9 @@ private:
   QColor bg = bg_colors[STATUS_DISENGAGED];
   QWidget *map = nullptr;
   QHBoxLayout* split;
+  // PFEIFER - AOL {{
+  Params params;
+  // }} PFEIFER - AOL
 
 private slots:
   void offroadTransition(bool offroad);

--- a/selfdrive/ui/ui.h
+++ b/selfdrive/ui/ui.h
@@ -94,6 +94,9 @@ typedef enum UIStatus {
   STATUS_DISENGAGED,
   STATUS_OVERRIDE,
   STATUS_ENGAGED,
+  // PFEIFER - AOL {{
+  STATUS_LAT_ACTIVE,
+  // }} PFEIFER - AOL
 } UIStatus;
 
 enum PrimeType {
@@ -109,6 +112,9 @@ const QColor bg_colors [] = {
   [STATUS_DISENGAGED] = QColor(0x17, 0x33, 0x49, 0xc8),
   [STATUS_OVERRIDE] = QColor(0x91, 0x9b, 0x95, 0xf1),
   [STATUS_ENGAGED] = QColor(0x17, 0x86, 0x44, 0xf1),
+  // PFEIFER - AOL {{
+  [STATUS_LAT_ACTIVE] = QColor(0x6f, 0xc0, 0xc9, 0xf1),
+  // }} PFEIFER - AOL
 };
 
 static std::map<cereal::ControlsState::AlertStatus, QColor> alert_colors = {


### PR DESCRIPTION
Provides support for Always On Lateral on some cars. Note that always on lateral requires changes to panda safety code so please refer to the corresponding panda commit to read and understand those changes. To engage lateral you must have engaged cruise control at least once after pressing the main button. Once cruise control has been engaged lateral will remain on after a brake press or the cancel button has been pressed. Pressing the cruise main button again will disable lateral control.